### PR TITLE
Restrict number of threads for PyTorch

### DIFF
--- a/curl/Makefile
+++ b/curl/Makefile
@@ -3,8 +3,6 @@ CURL_DIR ?= /usr/bin
 
 ARCH_LIBDIR ?= /lib/$(shell $(CC) -dumpmachine)
 
-SGX_SIGNER_KEY ?= ../../Pal/src/host/Linux-SGX/signer/enclave-key.pem
-
 ifeq ($(DEBUG),1)
 GRAMINE_LOG_LEVEL = debug
 else
@@ -26,10 +24,7 @@ curl.manifest: curl.manifest.template
 		$< >$@
 
 curl.manifest.sgx: curl.manifest
-	@test -s $(SGX_SIGNER_KEY) || \
-	    { echo "SGX signer private key was not found, please specify SGX_SIGNER_KEY!"; exit 1; }
 	gramine-sgx-sign \
-		--key $(SGX_SIGNER_KEY) \
 		--manifest curl.manifest \
 		--output $@
 

--- a/curl/curl.manifest.template
+++ b/curl/curl.manifest.template
@@ -10,25 +10,13 @@ loader.env.HOME = "{{ home }}"
 
 loader.insecure__use_cmdline_argv = true
 
-fs.mount.lib.type = "chroot"
-fs.mount.lib.path = "/lib"
-fs.mount.lib.uri = "file:{{ gramine.runtimedir() }}"
-
-fs.mount.lib2.type = "chroot"
-fs.mount.lib2.path = "{{ arch_libdir }}"
-fs.mount.lib2.uri = "file:{{ arch_libdir }}"
-
-fs.mount.lib3.type = "chroot"
-fs.mount.lib3.path = "/usr{{ arch_libdir }}"
-fs.mount.lib3.uri = "file:/usr/{{ arch_libdir }}"
-
-fs.mount.etc.type = "chroot"
-fs.mount.etc.path = "/etc"
-fs.mount.etc.uri = "file:/etc"
-
-fs.mount.curl.type = "chroot"
-fs.mount.curl.path = "{{ curl_dir }}"
-fs.mount.curl.uri = "file:{{ curl_dir }}"
+fs.mounts = [
+  { type = "chroot", uri = "file:{{ gramine.runtimedir() }}", path = "/lib" },
+  { type = "chroot", uri = "file:{{ arch_libdir }}", path = "{{ arch_libdir }}" },
+  { type = "chroot", uri = "file:/usr/{{ arch_libdir }}", path = "/usr{{ arch_libdir }}" },
+  { type = "chroot", uri = "file:/etc", path = "/etc" },
+  { type = "chroot", uri = "file:{{ curl_dir }}", path = "{{ curl_dir }}" },
+]
 
 sgx.enclave_size = "256M"
 sgx.thread_num = 4

--- a/gcc/Makefile
+++ b/gcc/Makefile
@@ -3,8 +3,6 @@ THIS_DIR := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
 ARCH_LONG ?= $(shell $(CC) -dumpmachine)
 ARCH_LIBDIR ?= /lib/$(shell $(CC) -dumpmachine)
 
-SGX_SIGNER_KEY ?= ../../Pal/src/host/Linux-SGX/signer/enclave-key.pem
-
 BZIP2_MIRRORS ?= \
 	https://people.csail.mit.edu/smcc/projects/single-file-programs/bzip2.c \
 	https://packages.gramineproject.io/distfiles/single-file-programs/bzip2.c
@@ -46,10 +44,7 @@ gcc.sig gcc.manifest.sgx: sgx_outputs
 
 .INTERMEDIATE: sgx_outputs
 sgx_outputs: gcc.manifest
-	@test -s $(SGX_SIGNER_KEY) || \
-	    { echo "SGX signer private key was not found, please specify SGX_SIGNER_KEY!"; exit 1; }
 	gramine-sgx-sign \
-		--key $(SGX_SIGNER_KEY) \
 		--manifest gcc.manifest \
 		--output gcc.manifest.sgx
 

--- a/gcc/gcc.manifest.template
+++ b/gcc/gcc.manifest.template
@@ -11,21 +11,13 @@ loader.env.PATH = "/bin:/usr/bin"
 
 loader.insecure__use_cmdline_argv = true
 
-fs.mount.lib1.type = "chroot"
-fs.mount.lib1.path = "/lib"
-fs.mount.lib1.uri = "file:{{ gramine.runtimedir() }}"
-
-fs.mount.lib2.type = "chroot"
-fs.mount.lib2.path = "{{ arch_libdir }}"
-fs.mount.lib2.uri = "file:{{ arch_libdir }}"
-
-fs.mount.usr.type = "chroot"
-fs.mount.usr.path = "/usr"
-fs.mount.usr.uri = "file:/usr"
-
-fs.mount.tmp.type = "chroot"
-fs.mount.tmp.path = "/tmp"
-fs.mount.tmp.uri = "file:/tmp"
+fs.mounts = [
+  { type = "chroot", uri = "file:{{ gramine.runtimedir() }}", path = "/lib" },
+  { type = "chroot", uri = "file:{{ arch_libdir }}", path = "{{ arch_libdir }}" },
+  { type = "chroot", uri = "file:/usr", path = "/usr" },
+  { type = "chroot", uri = "file:/tmp", path = "/tmp" },
+  { type = "chroot", uri = "file:/lib64", path = "/lib64" },
+]
 
 sgx.enclave_size = "1G"
 sgx.nonpie_binary = true
@@ -39,7 +31,7 @@ sgx.trusted_files = [
   "file:{{ arch_libdir }}/",
   "file:/usr/{{ arch_libdir }}/",
   "file:{{ gcc_lib_path }}/{{ gcc_major_version }}/",
-  "file:/usr/lib/debug/usr/{{ arch_libdir }}/",
+  "file:/lib64/",
 ]
 
 sgx.allowed_files = [

--- a/nodejs/Makefile
+++ b/nodejs/Makefile
@@ -3,8 +3,6 @@ NODEJS_DIR ?= /usr/bin
 
 ARCH_LIBDIR ?= /lib/$(shell $(CC) -dumpmachine)
 
-SGX_SIGNER_KEY ?= ../../Pal/src/host/Linux-SGX/signer/enclave-key.pem
-
 ifeq ($(DEBUG),1)
 GRAMINE_LOG_LEVEL = debug
 else
@@ -25,10 +23,7 @@ nodejs.manifest: nodejs.manifest.template
 		$< >$@
 
 nodejs.manifest.sgx: nodejs.manifest helloworld.js
-	@test -s $(SGX_SIGNER_KEY) || \
-	    { echo "SGX signer private key was not found, please specify SGX_SIGNER_KEY!"; exit 1; }
 	gramine-sgx-sign \
-		--key $(SGX_SIGNER_KEY) \
 		--manifest $< \
 		--output $@
 

--- a/nodejs/nodejs.manifest.template
+++ b/nodejs/nodejs.manifest.template
@@ -13,21 +13,12 @@ loader.insecure__use_host_env = true
 # Node.js requires eventfd2() emulation otherwise fails on `(uv_loop_init(&tracing_loop_)) == (0)'
 sys.insecure__allow_eventfd = true
 
-fs.mount.nodejs.type = "chroot"
-fs.mount.nodejs.path = "{{ nodejs_dir }}/nodejs"
-fs.mount.nodejs.uri = "file:{{ nodejs_dir }}/nodejs"
-
-fs.mount.lib.type = "chroot"
-fs.mount.lib.path = "/lib"
-fs.mount.lib.uri = "file:{{ gramine.runtimedir() }}"
-
-fs.mount.lib2.type = "chroot"
-fs.mount.lib2.path = "{{ arch_libdir }}"
-fs.mount.lib2.uri = "file:{{ arch_libdir }}"
-
-fs.mount.lib3.type = "chroot"
-fs.mount.lib3.path = "/usr/{{ arch_libdir }}"
-fs.mount.lib3.uri = "file:/usr/{{ arch_libdir }}"
+fs.mounts = [
+  { type = "chroot", uri = "file:{{ gramine.runtimedir() }}", path = "/lib" },
+  { type = "chroot", uri = "file:{{ arch_libdir }}", path = "{{ arch_libdir }}" },
+  { type = "chroot", uri = "file:/usr/{{ arch_libdir }}", path = "/usr/{{ arch_libdir }}" },
+  { type = "chroot", uri = "file:{{ nodejs_dir }}/nodejs", path = "{{ nodejs_dir }}/nodejs" },
+]
 
 sgx.nonpie_binary = true
 # Node.js expects around 1.7GB of heap on startup, see https://github.com/nodejs/node/issues/13018

--- a/openjdk/Makefile
+++ b/openjdk/Makefile
@@ -1,7 +1,5 @@
 ARCH_LIBDIR ?= /lib/$(shell $(CC) -dumpmachine)
 
-SGX_SIGNER_KEY ?= ../../Pal/src/host/Linux-SGX/signer/enclave-key.pem
-
 ifeq ($(DEBUG),1)
 GRAMINE_LOG_LEVEL = debug
 else
@@ -30,10 +28,7 @@ java.manifest: java.manifest.template
 		$< >$@
 
 java.manifest.sgx: java.manifest
-	@test -s $(SGX_SIGNER_KEY) || \
-		{ echo "SGX signer private key was not found, please specify SGX_SIGNER_KEY!"; exit 1; }
 	gramine-sgx-sign \
-		--key $(SGX_SIGNER_KEY) \
 		--manifest $< \
 		--output $@
 

--- a/openjdk/java.manifest.template
+++ b/openjdk/java.manifest.template
@@ -7,17 +7,11 @@ loader.insecure__use_cmdline_argv = true
 
 loader.env.LD_LIBRARY_PATH = "/lib:{{ arch_libdir }}:/usr/lib:/usr/{{ arch_libdir }}"
 
-fs.mount.lib.type = "chroot"
-fs.mount.lib.path = "/lib"
-fs.mount.lib.uri = "file:{{ gramine.runtimedir() }}"
-
-fs.mount.lib2.type = "chroot"
-fs.mount.lib2.path = "{{ arch_libdir }}"
-fs.mount.lib2.uri = "file:{{ arch_libdir }}"
-
-fs.mount.usr.type = "chroot"
-fs.mount.usr.path = "/usr"
-fs.mount.usr.uri = "file:/usr"
+fs.mounts = [
+  { type = "chroot", uri = "file:{{ gramine.runtimedir() }}", path = "/lib" },
+  { type = "chroot", uri = "file:{{ arch_libdir }}", path = "{{ arch_libdir }}" },
+  { type = "chroot", uri = "file:/usr", path = "/usr" },
+]
 
 # If using 64G or greater enclave sizes, the JVM flag `-Xmx8G` can be omitted in gramine-sgx.
 sgx.enclave_size = "16G"

--- a/openvino/Makefile
+++ b/openvino/Makefile
@@ -22,8 +22,6 @@ PUBLIC_MODELS = \
 
 VENV_DIR ?= $(THIS_DIR)/openvino
 
-SGX_SIGNER_KEY ?= ../../Pal/src/host/Linux-SGX/signer/enclave-key.pem
-
 ifeq ($(DEBUG),1)
 GRAMINE_LOG_LEVEL = debug
 else
@@ -84,10 +82,7 @@ benchmark_app.manifest: benchmark_app.manifest.template
 		$< > $@
 
 benchmark_app.manifest.sgx: benchmark_app.manifest | benchmark_app
-	@test -s $(SGX_SIGNER_KEY) || \
-	    { echo "SGX signer private key was not found, please specify SGX_SIGNER_KEY!"; exit 1; }
 	gramine-sgx-sign \
-		--key $(SGX_SIGNER_KEY) \
 		--manifest $< \
 		--output $@
 

--- a/openvino/benchmark_app.manifest.template
+++ b/openvino/benchmark_app.manifest.template
@@ -5,29 +5,14 @@ loader.log_level = "{{ log_level }}"
 
 loader.env.LD_LIBRARY_PATH = "/lib:{{ openvino_dir }}/deployment_tools/inference_engine/external/tbb/lib:{{ openvino_dir }}/deployment_tools/inference_engine/lib/intel64:{{ openvino_dir }}/opencv/lib:{{ openvino_dir }}/deployment_tools/ngraph/lib:{{ arch_libdir }}:/usr/{{ arch_libdir }}"
 
-fs.mount.lib.type = "chroot"
-fs.mount.lib.path = "/lib"
-fs.mount.lib.uri = "file:{{ gramine.runtimedir() }}"
-
-fs.mount.lib2.type = "chroot"
-fs.mount.lib2.path = "{{ arch_libdir }}"
-fs.mount.lib2.uri = "file:{{ arch_libdir }}"
-
-fs.mount.lib3.type = "chroot"
-fs.mount.lib3.path = "/usr/{{ arch_libdir }}"
-fs.mount.lib3.uri = "file:/usr/{{ arch_libdir }}"
-
-fs.mount.etc.type = "chroot"
-fs.mount.etc.path = "/etc"
-fs.mount.etc.uri = "file:/etc"
-
-fs.mount.openvino.type = "chroot"
-fs.mount.openvino.path = "{{ openvino_dir }}"
-fs.mount.openvino.uri = "file:{{ openvino_dir }}"
-
-fs.mount.samples.type = "chroot"
-fs.mount.samples.path = "{{ inference_engine_cpp_samples_build }}"
-fs.mount.samples.uri = "file:{{ inference_engine_cpp_samples_build }}"
+fs.mounts = [
+  { type = "chroot", uri = "file:{{ gramine.runtimedir() }}", path = "/lib" },
+  { type = "chroot", uri = "file:{{ arch_libdir }}", path = "{{ arch_libdir }}" },
+  { type = "chroot", uri = "file:/usr/{{ arch_libdir }}", path = "/usr/{{ arch_libdir }}" },
+  { type = "chroot", uri = "file:/etc", path = "/etc" },
+  { type = "chroot", uri = "file:{{ openvino_dir }}", path = "{{ openvino_dir }}" },
+  { type = "chroot", uri = "file:{{ inference_engine_cpp_samples_build }}", path = "{{ inference_engine_cpp_samples_build }}" },
+]
 
 loader.insecure__use_cmdline_argv = true
 
@@ -39,6 +24,7 @@ libos.check_invalid_pointers = false
 
 sgx.trusted_files = [
   "file:benchmark_app",
+  "file:{{ gramine.libos }}",
   "file:{{ gramine.runtimedir() }}/",
   "file:{{ arch_libdir }}/",
   "file:/usr/{{ arch_libdir }}/",

--- a/pytorch/Makefile
+++ b/pytorch/Makefile
@@ -2,7 +2,8 @@
 
 ARCH_LIBDIR ?= /lib/$(shell $(CC) -dumpmachine)
 
-SGX_SIGNER_KEY ?= ../../Pal/src/host/Linux-SGX/signer/enclave-key.pem
+# PyTorch uses the Pillow backend; detect where Pillow was installed
+PILLOW_PATH ?= $(shell pip3 show pillow | grep Location: | cut -d" " -f2)/
 
 ifeq ($(DEBUG),1)
 GRAMINE_LOG_LEVEL = debug
@@ -19,6 +20,7 @@ endif
 %.manifest: %.manifest.template
 	gramine-manifest \
 		-Dlog_level=$(GRAMINE_LOG_LEVEL) \
+		-Dpillow_path=$(PILLOW_PATH) \
 		-Darch_libdir=$(ARCH_LIBDIR) \
 		-Dentrypoint=$(realpath $(shell sh -c "command -v python3")) \
 		$< > $@
@@ -30,10 +32,7 @@ pytorch.sig pytorch.manifest.sgx: sgx_outputs
 
 .INTERMEDIATE: sgx_outputs
 sgx_outputs: pytorch.manifest
-	@test -s $(SGX_SIGNER_KEY) || \
-	    { echo "SGX signer private key was not found, please specify SGX_SIGNER_KEY!"; exit 1; }
 	gramine-sgx-sign \
-		--key $(SGX_SIGNER_KEY) \
 		--output pytorch.manifest.sgx \
 		--manifest pytorch.manifest
 

--- a/pytorch/pytorch.manifest.template
+++ b/pytorch/pytorch.manifest.template
@@ -7,6 +7,10 @@ loader.log_level = "{{ log_level }}"
 
 loader.env.LD_LIBRARY_PATH = "/lib:/usr/lib:{{ arch_libdir }}:/usr/{{ arch_libdir }}"
 
+# Restrict the maximum number of threads to prevent insufficient memory
+# issue, observed on CentOS/RHEL.
+loader.env.OMP_NUM_THREADS = "8"
+
 loader.insecure__use_cmdline_argv = true
 loader.insecure__use_host_env = true
 

--- a/pytorch/pytorch.manifest.template
+++ b/pytorch/pytorch.manifest.template
@@ -12,35 +12,18 @@ loader.insecure__use_host_env = true
 
 loader.pal_internal_mem_size = "128M"
 
-fs.mount.lib.type = "chroot"
-fs.mount.lib.path = "/lib"
-fs.mount.lib.uri = "file:{{ gramine.runtimedir() }}/"
-
-fs.mount.lib2.type = "chroot"
-fs.mount.lib2.path = "{{ arch_libdir }}"
-fs.mount.lib2.uri = "file:{{ arch_libdir }}"
-
-fs.mount.usr.type = "chroot"
-fs.mount.usr.path = "/usr"
-fs.mount.usr.uri = "file:/usr"
-
-fs.mount.etc.type = "chroot"
-fs.mount.etc.path = "/etc"
-fs.mount.etc.uri = "file:/etc"
-
-fs.mount.tmp.type = "chroot"
-fs.mount.tmp.path = "/tmp"
-fs.mount.tmp.uri = "file:/tmp"
+fs.mounts = [
+  { type = "chroot", uri = "file:{{ gramine.runtimedir() }}", path = "/lib" },
+  { type = "chroot", uri = "file:{{ arch_libdir }}", path = "{{ arch_libdir }}" },
+  { type = "chroot", uri = "file:/usr", path = "/usr" },
+  { type = "chroot", uri = "file:/etc", path = "/etc" },
+  { type = "chroot", uri = "file:/tmp", path = "/tmp" },
+  { type = "chroot", uri = "file:{{ pillow_path }}", path = "{{ pillow_path }}" },
+]
 
 # PyTorch loads its pre-trained models from here
-# Uncomment lines below if you want to use torchvision.model.alexnet(pretrained=True)
-# fs.mount.torch.type = "chroot"
-# fs.mount.torch.path = "{{ env.HOME }}/.cache/torch"
-# fs.mount.torch.uri = "file:{{ env.HOME }}/.cache/torch"
-
-fs.mount.pip.type = "chroot"
-fs.mount.pip.path = "{{ env.HOME }}/.local/lib"
-fs.mount.pip.uri = "file:{{ env.HOME }}/.local/lib"
+# Add below uncommented line to fs.mounts array if you want to use torchvision.model.alexnet(pretrained=True)
+# { type = "chroot", uri = "file:{{ env.HOME }}/.cache/torch", path = "{{ env.HOME }}/.cache/torch" }
 
 sgx.nonpie_binary = true
 sgx.enclave_size = "16G"
@@ -54,7 +37,7 @@ sgx.trusted_files = [
   "file:/usr/{{ arch_libdir }}/",
   "file:{{ python.stdlib }}/",
   "file:{{ python.distlib }}/",
-  "file:{{ env.HOME }}/.local/lib/",
+  "file:{{ pillow_path }}",
   "file:{{ python.get_path('stdlib', vars={'installed_base': '/usr/local'}) }}/",
 
   "file:pytorchexample.py",

--- a/r/Makefile
+++ b/r/Makefile
@@ -2,8 +2,6 @@
 R_HOME ?= /usr/lib/R
 R_EXEC = $(R_HOME)/bin/exec/R
 
-SGX_SIGNER_KEY ?= ../../Pal/src/host/Linux-SGX/signer/enclave-key.pem
-
 ARCH_LIBDIR ?= /lib/$(shell $(CC) -dumpmachine)
 
 ifeq ($(DEBUG),1)
@@ -30,10 +28,7 @@ R.manifest: R.manifest.template
 		$< >$@
 
 %.manifest.sgx: %.manifest
-	@test -s $(SGX_SIGNER_KEY) || \
-	    { echo "SGX signer private key was not found, please specify SGX_SIGNER_KEY!"; exit 1; }
 	gramine-sgx-sign \
-		--key $(SGX_SIGNER_KEY) \
 		--manifest $< \
 		--output $@
 

--- a/r/R.manifest.template
+++ b/r/R.manifest.template
@@ -17,29 +17,14 @@ loader.insecure__use_cmdline_argv = true
 
 sys.enable_sigterm_injection = true
 
-fs.mount.lib.type = "chroot"
-fs.mount.lib.path = "/lib"
-fs.mount.lib.uri = "file:{{ gramine.runtimedir() }}"
-
-fs.mount.lib2.type = "chroot"
-fs.mount.lib2.path = "{{ arch_libdir }}"
-fs.mount.lib2.uri = "file:{{ arch_libdir }}"
-
-fs.mount.usr.type = "chroot"
-fs.mount.usr.path = "/usr"
-fs.mount.usr.uri = "file:/usr"
-
-fs.mount.r_home.type = "chroot"
-fs.mount.r_home.path = "{{ r_home }}"
-fs.mount.r_home.uri = "file:{{ r_home }}"
-
-fs.mount.tmp.type = "chroot"
-fs.mount.tmp.path = "/tmp"
-fs.mount.tmp.uri = "file:/tmp"
-
-fs.mount.bin.type = "chroot"
-fs.mount.bin.path = "/bin"
-fs.mount.bin.uri = "file:/bin"
+fs.mounts = [
+  { type = "chroot", uri = "file:{{ gramine.runtimedir() }}", path = "/lib" },
+  { type = "chroot", uri = "file:{{ arch_libdir }}", path = "{{ arch_libdir }}" },
+  { type = "chroot", uri = "file:/usr", path = "/usr" },
+  { type = "chroot", uri = "file:/tmp", path = "/tmp" },
+  { type = "chroot", uri = "file:/bin", path = "/bin" },
+  { type = "chroot", uri = "file:{{ r_home }}", path = "{{ r_home }}" },
+]
 
 sgx.nonpie_binary = true
 sys.stack.size = "8M"

--- a/tensorflow-lite/Makefile
+++ b/tensorflow-lite/Makefile
@@ -2,8 +2,6 @@ manifests = $(addsuffix .manifest,label_image)
 exec_target = $(manifests)
 target = label_image
 
-SGX_SIGNER_KEY ?= ../../Pal/src/host/Linux-SGX/signer/enclave-key.pem
-
 ARCH_LIBDIR ?= /lib/$(shell $(CC) -dumpmachine)
 
 TF_DIR ?= tensorflow
@@ -65,10 +63,7 @@ label_image.manifest: label_image.manifest.template libtensorflow_framework.so l
 		$< > $@
 
 label_image.manifest.sgx: label_image.manifest inception_v3.tflite labels.txt
-	@test -s $(SGX_SIGNER_KEY) || \
-	    { echo "SGX signer private key was not found, please specify SGX_SIGNER_KEY!"; exit 1; }
 	gramine-sgx-sign \
-		--key $(SGX_SIGNER_KEY) \
 		--manifest $< \
 		--output $@
 	gramine-sgx-get-token \

--- a/tensorflow-lite/label_image.manifest.template
+++ b/tensorflow-lite/label_image.manifest.template
@@ -10,17 +10,11 @@ loader.env.PATH = "/bin:/usr/bin"
 
 loader.insecure__use_cmdline_argv = true
 
-fs.mount.lib1.type = "chroot"
-fs.mount.lib1.path = "/lib"
-fs.mount.lib1.uri = "file:{{ gramine.runtimedir() }}"
-
-fs.mount.lib2.type = "chroot"
-fs.mount.lib2.path = "{{ arch_libdir }}"
-fs.mount.lib2.uri = "file:{{ arch_libdir }}"
-
-fs.mount.lib3.type = "chroot"
-fs.mount.lib3.path = "/usr{{ arch_libdir }}"
-fs.mount.lib3.uri = "file:/usr{{ arch_libdir }}"
+fs.mounts = [
+  { type = "chroot", uri = "file:{{ gramine.runtimedir() }}", path = "/lib" },
+  { type = "chroot", uri = "file:{{ arch_libdir }}", path = "{{ arch_libdir }}" },
+  { type = "chroot", uri = "file:/usr/{{ arch_libdir }}", path = "/usr/{{ arch_libdir }}" },
+]
 
 sgx.nonpie_binary = true
 sgx.enclave_size = "512M"


### PR DESCRIPTION
The number of threads is restricted to prevent from running out of
memory for Gramine-SGX. This is required after sysfs topology was
enabled by default in core Gramine.